### PR TITLE
Parse point expression before getting value

### DIFF
--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 import sys
 import logging
 import json
@@ -109,7 +108,7 @@ class Mqtt2InfluxDB:
 
                 if 'fields' in point:
                     for key in point['fields']:
-                        val = self._get_value_from_str_or_JSONPath(point['fields'][key], msg)
+                        val = self._get_value_from_str_or_JSONPath(jsonpath_ng.parse(point['fields'][key]), msg)
                         if val is None:
                             continue
                         record['fields'][key] = val
@@ -123,7 +122,7 @@ class Mqtt2InfluxDB:
 
                 if 'tags' in point:
                     for key in point['tags']:
-                        val = self._get_value_from_str_or_JSONPath(point['tags'][key], msg)
+                        val = self._get_value_from_str_or_JSONPath(jsonpath_ng.parse(point['tags'][key]), msg)
                         if val is None:
                             continue
                         record['tags'][key] = val


### PR DESCRIPTION
Hey,
I found small issue in `bch-mqtt2influxdb` -- method `_get_value_from_str_or_JSONPath` expect string OR `jsonpath_ng` object. In your version, you pass there values `fields` & `tags` from YML config file as string, which means that you store those expression also in DB.

For example, instead of record like

```
{'measurement': 'temperature', 'time': '2018-05-02T05:54:50Z', 'tags': {'id': 'kit-climate-monitor:0', 'channel': '0:0'}, 'fields': {'value': 21.12}}
```

you are currently storing this

```
{'measurement': 'temperature', 'time': '2018-05-02T05:54:50Z', 'tags': {'id': '$.topic[1]', 'channel': '$.topic[3]'}, 'fields': {'value': '$.payload'}}
```