### PR TITLE
Adding HTTP output and base64 decoding option

### DIFF
--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -53,7 +53,7 @@ schema = Schema({
     Optional("base64decode"): {
         'source': And(str, len, Use(str_or_jsonPath)),
         'target': And(str, len)
-        },
+    },
     'points': [{
         'measurement': And(str, len, Use(str_or_jsonPath)),
         'topic': And(str, len),

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -35,6 +35,13 @@ schema = Schema({
         Optional('certfile'): os.path.exists,
         Optional('keyfile'): os.path.exists,
     },
+    Optional('http'): {
+        'destination': And(str, len),
+        'action': And(str, len),
+        Optional('username'): And(str, len),
+        Optional('password'): And(str, len),
+    },
+    
     'influxdb': {
         'host': And(str, len),
         'port': And(int, port_range),
@@ -43,9 +50,11 @@ schema = Schema({
         'database': And(str, len),
         Optional('ssl'): bool
     },
+    Optional("base64decode"): {str: And(str, len, Use(str_or_jsonPath))},
     'points': [{
         'measurement': And(str, len, Use(str_or_jsonPath)),
         'topic': And(str, len),
+        Optional('httpcontent'): {str: And(str, len, Use(str_or_jsonPath))},
         Optional('fields'): Or({str: And(str, len, Use(str_or_jsonPath))}, And(str, len, Use(str_or_jsonPath))),
         Optional('tags'): {str: And(str, len, Use(str_or_jsonPath))},
         Optional('database'): And(str, len)
@@ -55,7 +64,7 @@ schema = Schema({
 
 def load_config(config_filename):
     with open(config_filename, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.load(f, Loader=yaml.FullLoader)
         try:
             return schema.validate(config)
         except SchemaError as e:

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -41,7 +41,7 @@ schema = Schema({
         Optional('username'): And(str, len),
         Optional('password'): And(str, len),
     },
-    
+
     'influxdb': {
         'host': And(str, len),
         'port': And(int, port_range),

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -39,7 +39,7 @@ schema = Schema({
         'destination': And(str, len),
         'action': And(str, len),
         Optional('username'): And(str, len),
-        Optional('password'): And(str, len),
+        Optional('password'): And(str, len)
     },
 
     'influxdb': {
@@ -50,7 +50,10 @@ schema = Schema({
         'database': And(str, len),
         Optional('ssl'): bool
     },
-    Optional("base64decode"): {str: And(str, len, Use(str_or_jsonPath))},
+    Optional("base64decode"): {
+        'source': And(str, len, Use(str_or_jsonPath)),
+        'target': And(str, len)
+        },
     'points': [{
         'measurement': And(str, len, Use(str_or_jsonPath)),
         'topic': And(str, len),

--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -111,7 +111,7 @@ class Mqtt2InfluxDB:
                           'time': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
                           'tags': {},
                           'fields': {}}
-                if 'base64decode' in self._config.keys():
+                if 'base64decode' in self._config:
                     data = self._get_value_from_str_or_JSONPath(self._config['base64decode']["source"], msg)
                     dataDecoded = base64.b64decode(data)
                     msg.update({"base64decoded": {self._config['base64decode']["target"]: {"raw": dataDecoded}}})
@@ -149,7 +149,7 @@ class Mqtt2InfluxDB:
 
                 self._influxdb.write_points([record], database=point.get('database', None))
 
-                if 'http' in self._config.keys():
+                if 'http' in self._config:
                     http_record = {}
                     for key in point['httpcontent']:
                         val = self._get_value_from_str_or_JSONPath(point['httpcontent'][key], msg)

--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -114,9 +114,9 @@ class Mqtt2InfluxDB:
                 if 'base64decode' in self._config.keys():
                     data = self._get_value_from_str_or_JSONPath(self._config['base64decode']["source"], msg)
                     dataDecoded = base64.b64decode(data)
-                    msg.update({"base64decoded": {self._config['base64decode']["target"]: {"raw": dataDecoded }}})
+                    msg.update({"base64decoded": {self._config['base64decode']["target"]: {"raw": dataDecoded}}})
                     dataDecoded = dataDecoded.hex()
-                    msg.update({"base64decoded": {self._config['base64decode']["target"]: {"hex": dataDecoded }}})
+                    msg.update({"base64decoded": {self._config['base64decode']["target"]: {"hex": dataDecoded}}})
 
                 if 'fields' in point:
                     if isinstance(point['fields'], jsonpath_ng.JSONPath):
@@ -155,14 +155,13 @@ class Mqtt2InfluxDB:
                         val = self._get_value_from_str_or_JSONPath(point['httpcontent'][key], msg)
                         if val is None:
                             continue
-                        http_record.update({key:val})
+                        http_record.update({key: val})
 
                     action = getattr(requests, self._config['http']['action'], None)
                     if action:
-                        r = action(url = self._config['http']['destination'], data = http_record, auth = HTTPBasicAuth(self._config['http']['username'], self._config['http']['password']))
+                        r = action(url=self._config['http']['destination'], data=http_record, auth=HTTPBasicAuth(self._config['http']['username'], self._config['http']['password']))
                     else:
                         print("Invalid HTTP method key!")
-
 
     def _get_value_from_str_or_JSONPath(self, param, msg):
         if isinstance(param, str):


### PR DESCRIPTION
Hi,

we added some new options:
**HTTP output**
Can be used in parallel to the InfluxDB one and supports providing the target URL, HTTP method (GET/POST etc), username and password. The content of the HTTP request can be configured via the new key `httpcontent` inside the `points`.

**Base64 decoding**
A new first-level config key `base64decode` takes two sub keys `source` (JSONPath) and `target` (string). The decoded value is stored into `msg.base64decoded.[TARGET]` where `[TARGET]` is the name given in the configuration. It is stored there with two sub-keys: `raw` and `hex`, the latter holds the data as a hex-sting. 
This way, the base64 decoded data is available to InfluxDB and HTTP to be stored/transmitted.

We developed these options for our setup, where we receive data from metering hardware over a radio protocol, then relay it via LoRa using https://www.loraserver.io/ and then pushing it onwards to  a decoder with an HTTP API.