### PR TITLE
Add feature to define datatype for InfluxDB fields

### DIFF
--- a/config-bigclown.yml
+++ b/config-bigclown.yml
@@ -7,14 +7,32 @@ influxdb:
   port: 8086
   database: node
 
+http:
+  destination: https://example.com/content
+  action: post
+  username: username
+  password: password
+
+base64decode:
+  source: $.payload.data
+  target: data
+
 points:
   - measurement: temperature
+    database: my_database
     topic: node/+/thermometer/+/temperature
     fields:
-      value: $.payload
+      value: $.payload.data
+      decodedvalue: $.base64decoded.data.hex
+      foo: 
+        value: $.payload.foo
+        type: "float"
     tags:
       id: $.topic[1]
       channel: $.topic[3]
+    httpcontent:
+      frame: $.base64decoded.data.hex
+      skipBytes: "1"
 
   - measurement: relative-humidity
     topic: node/+/hygrometer/+/relative-humidity

--- a/config-bigclown.yml
+++ b/config-bigclown.yml
@@ -7,32 +7,14 @@ influxdb:
   port: 8086
   database: node
 
-http:
-  destination: https://example.com/content
-  action: post
-  username: username
-  password: password
-
-base64decode:
-  source: $.payload.data
-  target: data
-
 points:
   - measurement: temperature
-    database: my_database
     topic: node/+/thermometer/+/temperature
     fields:
-      value: $.payload.data
-      decodedvalue: $.base64decoded.data.hex
-      foo: 
-        value: $.payload.foo
-        type: "float"
+      value: $.payload
     tags:
       id: $.topic[1]
       channel: $.topic[3]
-    httpcontent:
-      frame: $.base64decoded.data.hex
-      skipBytes: "1"
 
   - measurement: relative-humidity
     topic: node/+/hygrometer/+/relative-humidity

--- a/config-features.yml
+++ b/config-features.yml
@@ -1,0 +1,35 @@
+mqtt:
+  host: 127.0.0.1
+  port: 1883
+
+influxdb:
+  host: 127.0.0.1
+  port: 8086
+  database: node
+
+http:
+  destination: https://example.com/content
+  action: post
+  username: username
+  password: password
+
+base64decode:
+  source: $.payload.data
+  target: data
+
+points:
+  - measurement: temperature
+    database: my_database
+    topic: node/+/thermometer/+/temperature
+    fields:
+      value: $.payload.data
+      decodedvalue: $.base64decoded.data.hex
+      foo: 
+        value: $.payload.foo
+        type: "float"
+    tags:
+      id: $.topic[1]
+      channel: $.topic[3]
+    httpcontent:
+      frame: $.base64decoded.data.hex
+      skipBytes: "1"

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -58,7 +58,7 @@ schema = Schema({
         'measurement': And(str, len, Use(str_or_jsonPath)),
         'topic': And(str, len),
         Optional('httpcontent'): {str: And(str, len, Use(str_or_jsonPath))},
-        Optional('fields'): Or({str: And(str, len, Use(str_or_jsonPath))}, And(str, len, Use(str_or_jsonPath))),
+        Optional('fields'): Or({str: Or(And(str, len, Use(str_or_jsonPath)), {'value': And(str, len, Use(str_or_jsonPath)),'type': And(str, len)})}, And(str, len, Use(str_or_jsonPath))),
         Optional('tags'): {str: And(str, len, Use(str_or_jsonPath))},
         Optional('database'): And(str, len)
     }]

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -58,7 +58,7 @@ schema = Schema({
         'measurement': And(str, len, Use(str_or_jsonPath)),
         'topic': And(str, len),
         Optional('httpcontent'): {str: And(str, len, Use(str_or_jsonPath))},
-        Optional('fields'): Or({str: Or(And(str, len, Use(str_or_jsonPath)), {'value': And(str, len, Use(str_or_jsonPath)),'type': And(str, len)})}, And(str, len, Use(str_or_jsonPath))),
+        Optional('fields'): Or({str: Or(And(str, len, Use(str_or_jsonPath)), {'value': And(str, len, Use(str_or_jsonPath)), 'type': And(str, len)})}, And(str, len, Use(str_or_jsonPath))),
         Optional('tags'): {str: And(str, len, Use(str_or_jsonPath))},
         Optional('database'): And(str, len)
     }]

--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -13,6 +13,7 @@ import requests
 import base64
 from requests.auth import HTTPBasicAuth
 import http.client as http_client
+import builtins
 
 
 class Mqtt2InfluxDB:
@@ -84,6 +85,7 @@ class Mqtt2InfluxDB:
         msg = None
 
         for point in self._points:
+
             if topic_matches_sub(point['topic'], message.topic):
                 if not msg:
                     payload = message.payload.decode('utf-8')
@@ -111,6 +113,7 @@ class Mqtt2InfluxDB:
                           'time': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
                           'tags': {},
                           'fields': {}}
+
                 if 'base64decode' in self._config:
                     data = self._get_value_from_str_or_JSONPath(self._config['base64decode']["source"], msg)
                     dataDecoded = base64.b64decode(data)
@@ -119,15 +122,26 @@ class Mqtt2InfluxDB:
                     msg.update({"base64decoded": {self._config['base64decode']["target"]: {"hex": dataDecoded}}})
 
                 if 'fields' in point:
+
                     if isinstance(point['fields'], jsonpath_ng.JSONPath):
                         record['fields'] = self._get_value_from_str_or_JSONPath(point['fields'], msg)
+
                     else:
                         for key in point['fields']:
-                            val = self._get_value_from_str_or_JSONPath(point['fields'][key], msg)
+                            if isinstance(point['fields'][key], dict):
+                                val = self._get_value_from_str_or_JSONPath(point['fields'][key]['value'], msg)
+                                convFunc = getattr(builtins, point['fields'][key]['type'], None) 
+                                if convFunc:
+                                    try:
+                                        val = convFunc(val)
+                                    except:
+                                        val = None
+                                        logging.warning('invalid conversion function key')
+                            else:
+                                val = self._get_value_from_str_or_JSONPath(point['fields'][key], msg)
                             if val is None:
                                 continue
                             record['fields'][key] = val
-
                         if len(record['fields']) != len(point['fields']):
                             logging.warning('different number of fields')
 

--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -130,11 +130,11 @@ class Mqtt2InfluxDB:
                         for key in point['fields']:
                             if isinstance(point['fields'][key], dict):
                                 val = self._get_value_from_str_or_JSONPath(point['fields'][key]['value'], msg)
-                                convFunc = getattr(builtins, point['fields'][key]['type'], None) 
+                                convFunc = getattr(builtins, point['fields'][key]['type'], None)
                                 if convFunc:
                                     try:
                                         val = convFunc(val)
-                                    except:
+                                    except ValueError:
                                         val = None
                                         logging.warning('invalid conversion function key')
                             else:


### PR DESCRIPTION
Hi again :)
We ran into an issue, where the InfluxDB creates a field based on the first value received, if you try to e.g. write `value=1`. the field will be created as int. If your datatype then changes, e.g. to `1.1`, InlfuxDB cannot accept it anymore.
That's why it is helpful to be able to specify the datatype right from the beginning, which is what we implemented in this PR. The config is still backwards compatible.
Also, we changed the config.yml file a little bit to reflect the latest changes and document the features (database per point, base64 decoding, HTTP push, explicit datatype per field), so that they're not so "hidden" ;)