### PR TITLE
fix crash if jsonpath returns None for val

### DIFF
--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -131,6 +131,8 @@ class Mqtt2InfluxDB:
                             if isinstance(point['fields'][key], dict):
                                 val = self._get_value_from_str_or_JSONPath(point['fields'][key]['value'], msg)
                                 convFunc = getattr(builtins, point['fields'][key]['type'], None)
+                                if val is None:
+                                    continue
                                 if convFunc:
                                     try:
                                         val = convFunc(val)


### PR DESCRIPTION
Add a check if the value is empty before trying to run the `convFunc`

Observed Error message:
```
Mar 14 16:20:03 homesrv mqtt2influxdb[3325576]: 2021-03-14 16:20:03,913 ERROR: float() argument must be a string or a number, not 'NoneType'                              
Mar 14 16:20:03 homesrv systemd[1]: mqtt2influxdb.service: Main process exited, code=exited, status=1/FAILURE
```