### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG ARCH=
+FROM ${ARCH}python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY . .
+CMD ["python3", "-m", "mqtt2influxdb.cli", "-c", "/config/config.yml"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 mqtt2influxdb -c /etc/hardwario/mqtt2influxdb.yaml --debug
 ```
 
+### Using docker
+`mqtt2influxdb` can also be run inside docker using docker-compose or a kubernetes cluster. By default, the configuration file is expected to be
+present in `/config/config.yml` (you can mount it using a volume, a ConfigMap, or by overriding the image).
+
 ## How to install & configure
 
 https://tower.hardwario.com/en/latest/tutorials/mqtt-to-influxdb/


### PR DESCRIPTION
Hi,
This MR adds a dockerfile to the project.

The `ARCH=` argument is used for `docker buildx` when building multi-arch images.

It'd be nice if you could add the auto-build CI and push these images on the dockerhub for each new version :-)

Cheers