### PR TITLE
Using timestamp in MQTT message if available

### DIFF
--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -126,7 +126,7 @@ class Mqtt2InfluxDB:
                 try:
                     if 'timestamp' in payload.keys():
                         print("timestamp found in MQTT message... let's use this one....")
-                        timestamp = datetime.fromtimestamp(payload['timestamp'])
+                        timestamp = datetime.fromtimestamp(payload['timestamp']).strftime('%Y-%m-%dT%H:%M:%SZ')
                     else:
                         print("no timestamp in MQTT message..")
                 except:

--- a/mqtt2influxdb/mqtt2influxdb.py
+++ b/mqtt2influxdb/mqtt2influxdb.py
@@ -122,8 +122,18 @@ class Mqtt2InfluxDB:
                     logging.warning('unknown measurement')
                     return
 
+                timestamp =  datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+                try:
+                    if 'timestamp' in payload.keys():
+                        print("timestamp found in MQTT message... let's use this one....")
+                        timestamp = datetime.fromtimestamp(payload['timestamp'])
+                    else:
+                        print("no timestamp in MQTT message..")
+                except:
+                    print("some error while trying to read time from mqtt message.... let's ignore, and use the current timestamp")
+
                 record = {'measurement': measurement,
-                          'time': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                          'time': timestamp,
                           'tags': {},
                           'fields': {}}
 


### PR DESCRIPTION
If the MQTT message contains a 'timestamp' value, this value will be used as timestamp in InfluxDB. It is assumed that the timestamp is an epoch value is seconds.
If there is no timestamp value or parsing fails, the current timestamp is being used.