### PR TITLE
influx: move to InfluxDB2

### DIFF
--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -77,12 +77,10 @@ schema = Schema({
     },
 
     'influxdb': {
-        'host': And(str, len),
-        'port': And(int, port_range),
-        Optional('username'): And(str, len),
-        Optional('password'): And(str, len),
-        'database': And(str, len),
-        Optional('ssl'): bool
+        'url': And(str, len),
+        'bucket': And(str, len),
+        Optional('org'): str,
+        Optional('token'): str,
     },
     Optional("base64decode"): {
         'source': And(str, len, Use(str_or_jsonPath)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML>=5.1.1
 paho-mqtt>=1.0
-influxdb
+influxdb-client[ciso]
 schema>=0.6.7
 jsonpath-ng>=1.4.3
 pycron>=3.0.0


### PR DESCRIPTION
Hi,
This MR removes support for influxDB1 and adds InfluxDB2 instead.

We could handle both v1 and v2 versions by allowing multiple sender plugins as POCed in #23 , what do you think ?

Cheers