### PR TITLE
Add environment variable support

### DIFF
--- a/mqtt2influxdb/cli.py
+++ b/mqtt2influxdb/cli.py
@@ -37,6 +37,8 @@ def main():
             disable_warnings()
 
         if args.test:
+            if args.debug:
+                print(config)
             print("The configuration file seems ok")
             return
 

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -134,10 +134,12 @@ def load_env_vars(config_data):
                 config_value = section_data.get(key)
 
                 # Prioritize config file. If ENV is set AND config value is missing (None) or empty (''), use ENV value.
-                if env_value is not None and (config_value is None or config_value == ''):
-                    section_data[key] = env_value
-                    # You may want to log this for debugging/transparency
-                    print(f"INFO: Overriding '{section}.{key}' with value from ENV '{env_key}'")
+                if env_value is not None: # and (config_value is None or config_value == ''):
+                    if env_value == '':
+                        del section_data[key]
+                    else:
+                        section_data[key] = env_value
+                    logging.debug(f"INFO: Overriding '{section}.{key}' with value from ENV '{env_key}'")
 
 
 def load_config(config_file):

--- a/mqtt2influxdb/config.py
+++ b/mqtt2influxdb/config.py
@@ -133,8 +133,8 @@ def load_env_vars(config_data):
                 env_value = os.getenv(env_key)
                 config_value = section_data.get(key)
 
-                # Prioritize config file. If ENV is set AND config value is missing (None) or empty (''), use ENV value.
-                if env_value is not None: # and (config_value is None or config_value == ''):
+                # Prioritize ENV.
+                if env_value is not None:
                     if env_value == '':
                         del section_data[key]
                     else:


### PR DESCRIPTION
This PR ads support for reading the username and password config values from environment variables

Supported environment variables:
- `MQTT_USERNAME` `MQTT_PASSWORD`
- `HTTP_USERNAME` `HTTP_PASSWORD`
- `INFLUXDB_USERNAME` `INFLUXDB_PASSWORD`

This variables will override the value from the config